### PR TITLE
Add productTagId for Sunny Boy Smart Energy 3.6, 4.0, 6.0

### DIFF
--- a/pysma/const.py
+++ b/pysma/const.py
@@ -621,6 +621,7 @@ SMATagList: Dict[int, str] = {
     19049: "STP6.0SE (SUNNY TRIPOWER 6.0 SE)",
     19050: "STP8.0SE (SUNNY TRIPOWER 8.0 SE)",
     19051: "STP10.0SE (SUNNY TRIPOWER 10.0 SE)",
+    19129: "Sunny Boy Smart Energy 4.0",
     19130: "Sunny Boy Smart Energy 5.0",
     200111: "Not connected",  # EV-Charger
     200112: "Sleep Mode",  # EV-Charger

--- a/pysma/const.py
+++ b/pysma/const.py
@@ -621,6 +621,8 @@ SMATagList: Dict[int, str] = {
     19049: "STP6.0SE (SUNNY TRIPOWER 6.0 SE)",
     19050: "STP8.0SE (SUNNY TRIPOWER 8.0 SE)",
     19051: "STP10.0SE (SUNNY TRIPOWER 10.0 SE)",
+    19085: "Sunny Boy Smart Energy 6.0",
+    19128: "Sunny Boy Smart Energy 3.6",
     19129: "Sunny Boy Smart Energy 4.0",
     19130: "Sunny Boy Smart Energy 5.0",
     200111: "Not connected",  # EV-Charger

--- a/pysma/definitions_ennexos.py
+++ b/pysma/definitions_ennexos.py
@@ -135,9 +135,9 @@ ennexosSensorProfiles: list[tuple[list[int], list[str]]] = [
             "Wl.SoftAcsConnStt",
         ],
     ),
-    # Sunny Boy Smart Energy 4.0, 5.0
+    # Sunny Boy Smart Energy 3.6, 4.0, 5.0, 6.0
     (
-        [19129, 19130],
+        [19085, 19128, 19129, 19130],
         [
             "Operation.Bat.Health.1",
             "Coolsys.Inverter.TmpVal.1",

--- a/pysma/definitions_ennexos.py
+++ b/pysma/definitions_ennexos.py
@@ -135,9 +135,9 @@ ennexosSensorProfiles: list[tuple[list[int], list[str]]] = [
             "Wl.SoftAcsConnStt",
         ],
     ),
-    # Sunny Boy Smart Energy 5.0
+    # Sunny Boy Smart Energy 4.0, 5.0
     (
-        [19130],
+        [19129, 19130],
         [
             "Operation.Bat.Health.1",
             "Coolsys.Inverter.TmpVal.1",


### PR DESCRIPTION
The SBSE4.0 is (most likely) very similar to the SBSE5.0. Just adding the productTagId helps `example.py` print a nice list of plausible values.

I discovered issue #3 just now and added the values provided there as well.