### PR TITLE
Fix SMA EM multicast membership reuse

### DIFF
--- a/pysma/device_em.py
+++ b/pysma/device_em.py
@@ -8,6 +8,7 @@ see https://cdn.sma.de/fileadmin/content/www.developer.sma.de/docs/EMETER-Protok
 import asyncio
 import base64
 import copy
+import errno
 import logging
 import socket
 import struct
@@ -45,7 +46,11 @@ class SMAspeedwireEM(Device):
 
     def __init__(self) -> None:
         """init"""
-        self.loop = asyncio.get_event_loop()
+        try:
+            self.loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
         self._transport: asyncio.BaseTransport | None = None
         self._protocol: SMAspeedwireEM | None = None
         self.transport: asyncio.BaseTransport | None = None
@@ -240,30 +245,49 @@ class SMAspeedwireEM(Device):
         multicast_group = "239.12.255.254"
         server_address = ("", 9522)
 
+        if getattr(self, "_sock", None) is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind(server_address)
+
+        binding_addrs = self._bindingAddr or [socket.INADDR_ANY]
+        normalized_addrs = list(dict.fromkeys(str(addr).strip() for addr in binding_addrs if str(addr).strip()))
+        if not normalized_addrs:
+            normalized_addrs = [socket.INADDR_ANY]
+
         if len(self._bindingAddr) == 0:
             self._bindingAddr = [socket.INADDR_ANY]
             mreq = struct.pack(
                 "4sL", socket.inet_aton(multicast_group), socket.INADDR_ANY
             )
-            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+            try:
+                sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+            except OSError as exc:
+                if exc.errno not in {errno.EADDRINUSE, errno.EALREADY}:
+                    raise
+                _LOGGER.debug("Multicast membership already active for %s", multicast_group)
         else:
-            _LOGGER.info("Binding to %s" % self._bindingAddr)
-            for addr in self._bindingAddr:
+            _LOGGER.info("Binding to %s", normalized_addrs)
+            for addr in normalized_addrs:
                 try:
-                    mreq = struct.pack(
-                        "4s4s",
-                        socket.inet_aton(multicast_group),
-                        socket.inet_aton(addr),
-                    )
                     sock.setsockopt(
                         socket.IPPROTO_IP,
                         socket.IP_ADD_MEMBERSHIP,
                         socket.inet_aton(multicast_group) + socket.inet_aton(addr),
                     )
-                except BaseException as exc:
+                except OSError as exc:
+                    if exc.errno in {errno.EADDRINUSE, errno.EALREADY}:
+                        _LOGGER.debug(
+                            "Multicast membership already active for %s on %s",
+                            multicast_group,
+                            addr,
+                        )
+                        continue
                     raise RuntimeError(
                         "Could not start multicast for %s. IP of the Interfaces must be used!"
                         % addr

--- a/tests/test_em.py
+++ b/tests/test_em.py
@@ -1,10 +1,10 @@
 """Test pysma init."""
 import asyncio
 import base64
+import errno
 import json
 import logging
-
-from aioresponses import aioresponses
+import socket
 
 from pysma.device_em import SMAspeedwireEM
 
@@ -23,7 +23,7 @@ class Test_SMAEM_class:
             await asyncio.sleep(0.6)
             sma.datagram_received(data, ("192.0.2.1", 4711))
 
-    async def test_json_timeout_error(self, mock_aioresponse: aioresponses) -> None:
+    async def test_json_timeout_error(self) -> None:
         """Basic Tests"""
         sma = SMAspeedwireEM()
         task = asyncio.create_task(self.looper(sma))
@@ -52,3 +52,31 @@ class Test_SMAEM_class:
             debug = await sma.get_debug()
             print(debug)
             assert debug["last_packet"] == debug["last_valid_packet"] == data["packet"]
+
+    def test_duplicate_multicast_membership_is_ignored(self, monkeypatch) -> None:
+        """Repeated discovery setup should not crash when the membership is already present."""
+        sma = SMAspeedwireEM()
+        sma._bindingAddr = []
+        membership_attempts = {"count": 0}
+
+        class FakeSocket:
+            def setsockopt(self, level, optname, value):
+                if optname == socket.IP_ADD_MEMBERSHIP:
+                    membership_attempts["count"] += 1
+                    if membership_attempts["count"] > 1:
+                        raise OSError(errno.EADDRINUSE, "Address in use")
+
+            def bind(self, *_args, **_kwargs):
+                return None
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: FakeSocket())
+
+        first_socket = sma._getDiscoverySocket()
+        second_socket = sma._getDiscoverySocket()
+
+        assert first_socket is not None
+        assert second_socket is not None
+        assert sma._bindingAddr == [socket.INADDR_ANY]


### PR DESCRIPTION
* Harden SMA EM discovery socket setup for repeated multicast joins
* Treat duplicate IP_ADD_MEMBERSHIP failures as already-joined memberships instead of aborting startup
* Add regression coverage for repeated discovery setup